### PR TITLE
Port from https://github.com/splinedrive/kianRiscV

### DIFF
--- a/Hardware/KianV-Apio/control_unit.v
+++ b/Hardware/KianV-Apio/control_unit.v
@@ -46,20 +46,20 @@ module control_unit (
         output wire                        PCWrite,
         output wire                        AdrSrc,
         output wire                        MemWrite,
-        input wire                         unaligned_access_load,
-        input wire                         unaligned_access_store,
-        input wire                         access_fault,
+        input  wire                        unaligned_access_load,
+        input  wire                        unaligned_access_store,
+        input  wire                        access_fault,
         output wire                        fetched_instr,
         output wire                        incr_inst_retired,
         output wire                        ALUOutWrite,
-        output wire                        amo_tmp_write,
-        output wire                        Aluout_or_amo_rd_wr_mux,
-        output wire                        amo_set_load_reserved_state,
-        output wire                        amo_intermediate_data,
-        output wire                        amo_intermediate_addr,
-        input  wire                        amo_load_reserved_state,
-        output wire                        AMOWb_en,
-        output wire                        amo_alu_op,
+        output wire                        amo_temp_write_operation,
+        output wire                        muxed_Aluout_or_amo_rd_wr,
+        output wire                        amo_set_reserved_state_load,
+        output wire                        amo_buffered_data,
+        output wire                        amo_buffered_address,
+        input  wire                        amo_reserved_state_load,
+        output wire                        select_ALUResult,
+        output wire                        select_amo_temp,
 
         // Exception Handler
         output wire exception_event,
@@ -95,8 +95,8 @@ module control_unit (
 
     assign mul_ext_ready = mul_ready | div_ready;
 
-    wire amo_load;
-    wire amo_store_op;
+    wire amo_data_load;
+    wire amo_operation_store;
 
     wire CSRvalid;
     main_fsm main_fsm_I (
@@ -124,16 +124,16 @@ module control_unit (
                  .RegWrite         (RegWrite),
                  .ALUOutWrite      (ALUOutWrite),
 
-                 .amo_tmp_write              (amo_tmp_write),
-                 .amo_load                   (amo_load),
-                 .amo_store_op               (amo_store_op),
-                 .Aluout_or_amo_rd_wr_mux    (Aluout_or_amo_rd_wr_mux),
-                 .amo_set_load_reserved_state(amo_set_load_reserved_state),
-                 .amo_intermediate_data      (amo_intermediate_data),
-                 .amo_intermediate_addr      (amo_intermediate_addr),
-                 .amo_load_reserved_state    (amo_load_reserved_state),
-                 .AMOWb_en                   (AMOWb_en),
-                 .amo_alu_op                 (amo_alu_op),
+                 .amo_temp_write_operation   (amo_temp_write_operation),
+                 .amo_data_load              (amo_data_load),
+                 .amo_operation_store        (amo_operation_store),
+                 .muxed_Aluout_or_amo_rd_wr  (muxed_Aluout_or_amo_rd_wr),
+                 .amo_set_reserved_state_load(amo_set_reserved_state_load),
+                 .amo_buffered_data          (amo_buffered_data),
+                 .amo_buffered_address       (amo_buffered_address),
+                 .amo_reserved_state_load    (amo_reserved_state_load),
+                 .select_ALUResult           (select_ALUResult),
+                 .select_amo_temp            (select_amo_temp),
                  .MemWrite                   (MemWrite),
                  .unaligned_access_load      (unaligned_access_load),
                  .unaligned_access_store     (unaligned_access_store),
@@ -146,9 +146,9 @@ module control_unit (
                  .wfi_event       (wfi_event),
                  .privilege_mode  (privilege_mode),
                  .csr_access_fault(csr_access_fault),
-                 .mstatus (mstatus),
-                 .mie     (mie    ),
-                 .mip     (mip    ),
+                 .mstatus         (mstatus),
+                 .mie             (mie),
+                 .mip             (mip),
 
                  .mem_valid(mem_valid),
                  .mem_ready(mem_ready),
@@ -159,12 +159,12 @@ module control_unit (
 
     load_decoder load_decoder_I (
                      funct3,
-                     amo_load,
+                     amo_data_load,
                      LOADop
                  );
     store_decoder store_decoder_I (
                       funct3,
-                      amo_store_op,
+                      amo_operation_store,
                       STOREop
                   );
 

--- a/Hardware/KianV-Apio/csr_exception_handler.v
+++ b/Hardware/KianV-Apio/csr_exception_handler.v
@@ -233,6 +233,7 @@ module csr_exception_handler #(
         exception_next_pc_nxt = exception_next_pc;
         exception_select_nxt = 1'b0;
         privilege_mode_nxt = privilege_mode;
+        temp_mstatus = 0;
 
         // fixme if (we & !rdonly)
         wdata_nxt = is_csr_clear ? rdata & ~wdata : is_csr_set ? rdata | wdata : wdata;

--- a/Hardware/KianV-Apio/kianv_harris_mc_edition.v
+++ b/Hardware/KianV-Apio/kianv_harris_mc_edition.v
@@ -84,14 +84,14 @@ module kianv_harris_mc_edition #(
     assign Rs2    = Instr[24:20];
     assign Rd     = Instr[11:7];
 
-    wire amo_tmp_write;
-    wire amo_set_load_reserved_state;
-    wire amo_intermediate_data;
-    wire amo_intermediate_addr;
-    wire amo_load_reserved_state;
-    wire Aluout_or_amo_rd_wr_mux;
-    wire AMOWb_en;
-    wire amo_alu_op;
+    wire amo_temp_write_operation;
+    wire amo_set_reserved_state_load;
+    wire amo_buffered_data;
+    wire amo_buffered_address;
+    wire amo_reserved_state_load;
+    wire muxed_Aluout_or_amo_rd_wr;
+    wire select_ALUResult;
+    wire select_amo_temp;
 
     // Exception Handler
     wire exception_event;
@@ -106,39 +106,39 @@ module kianv_harris_mc_edition #(
     wire [31:0] mip;
 
     control_unit control_unit_I (
-                     .clk              (clk),
-                     .resetn           (resetn),
-                     .op               (op),
-                     .funct3           (funct3),
-                     .funct7           (funct7),
-                     .immb10           (immb10),
-                     .Zero             (Zero),
-                     .Rs1              (Rs1),
-                     .Rs2              (Rs2),
-                     .Rd               (Rd),
-                     .ResultSrc        (ResultSrc),
-                     .ALUControl       (ALUControl),
-                     .ALUSrcA          (ALUSrcA),
-                     .ALUSrcB          (ALUSrcB),
-                     .ImmSrc           (ImmSrc),
-                     .STOREop          (STOREop),
-                     .LOADop           (LOADop),
-                     .CSRop            (CSRop),
-                     .CSRwe            (CSRwe),
-                     .CSRre            (CSRre),
-                     .RegWrite         (RegWrite),
-                     .PCWrite          (PCWrite),
-                     .AdrSrc           (AdrSrc),
-                     .MemWrite         (MemWrite),
-                     .fetched_instr    (fetched_instr),
-                     .incr_inst_retired(incr_inst_retired),
-                     .ALUOutWrite      (ALUOutWrite),
-                     .mem_valid        (mem_valid),
-                     .mem_ready        (mem_ready),
-                     .MULop            (MULop),
-                     .unaligned_access_load  (unaligned_access_load),
-                     .unaligned_access_store (unaligned_access_store),
-                     .access_fault (access_fault),
+                     .clk                   (clk),
+                     .resetn                (resetn),
+                     .op                    (op),
+                     .funct3                (funct3),
+                     .funct7                (funct7),
+                     .immb10                (immb10),
+                     .Zero                  (Zero),
+                     .Rs1                   (Rs1),
+                     .Rs2                   (Rs2),
+                     .Rd                    (Rd),
+                     .ResultSrc             (ResultSrc),
+                     .ALUControl            (ALUControl),
+                     .ALUSrcA               (ALUSrcA),
+                     .ALUSrcB               (ALUSrcB),
+                     .ImmSrc                (ImmSrc),
+                     .STOREop               (STOREop),
+                     .LOADop                (LOADop),
+                     .CSRop                 (CSRop),
+                     .CSRwe                 (CSRwe),
+                     .CSRre                 (CSRre),
+                     .RegWrite              (RegWrite),
+                     .PCWrite               (PCWrite),
+                     .AdrSrc                (AdrSrc),
+                     .MemWrite              (MemWrite),
+                     .fetched_instr         (fetched_instr),
+                     .incr_inst_retired     (incr_inst_retired),
+                     .ALUOutWrite           (ALUOutWrite),
+                     .mem_valid             (mem_valid),
+                     .mem_ready             (mem_ready),
+                     .MULop                 (MULop),
+                     .unaligned_access_load (unaligned_access_load),
+                     .unaligned_access_store(unaligned_access_store),
+                     .access_fault          (access_fault),
 
                      .mul_valid                  (mul_valid),
                      .mul_ready                  (mul_ready),
@@ -146,25 +146,25 @@ module kianv_harris_mc_edition #(
                      .div_valid                  (div_valid),
                      .div_ready                  (div_ready),
                      // AMO
-                     .amo_tmp_write              (amo_tmp_write),
-                     .amo_set_load_reserved_state(amo_set_load_reserved_state),
-                     .amo_intermediate_data      (amo_intermediate_data),
-                     .amo_intermediate_addr      (amo_intermediate_addr),
-                     .amo_load_reserved_state    (amo_load_reserved_state),
-                     .Aluout_or_amo_rd_wr_mux    (Aluout_or_amo_rd_wr_mux),
-                     .AMOWb_en                   (AMOWb_en),
-                     .amo_alu_op                 (amo_alu_op),
+                     .amo_temp_write_operation   (amo_temp_write_operation),
+                     .amo_set_reserved_state_load(amo_set_reserved_state_load),
+                     .amo_buffered_data          (amo_buffered_data),
+                     .amo_buffered_address       (amo_buffered_address),
+                     .amo_reserved_state_load    (amo_reserved_state_load),
+                     .muxed_Aluout_or_amo_rd_wr  (muxed_Aluout_or_amo_rd_wr),
+                     .select_ALUResult           (select_ALUResult),
+                     .select_amo_temp            (select_amo_temp),
 
-                     .exception_event            (exception_event),
-                     .cause                      (cause),
-                     .badaddr                    (badaddr),
-                     .mret                       (mret),
-                     .wfi_event                  (wfi_event),
-                     .privilege_mode             (privilege_mode),
-                     .csr_access_fault           (csr_access_fault),
-                     .mstatus (mstatus),
-                     .mie     (mie    ),
-                     .mip     (mip    )
+                     .exception_event (exception_event),
+                     .cause           (cause),
+                     .badaddr         (badaddr),
+                     .mret            (mret),
+                     .wfi_event       (wfi_event),
+                     .privilege_mode  (privilege_mode),
+                     .csr_access_fault(csr_access_fault),
+                     .mstatus         (mstatus),
+                     .mie             (mie),
+                     .mip             (mip)
                  );
 
     datapath_unit #(
@@ -198,11 +198,11 @@ module kianv_harris_mc_edition #(
                       .Instr            (Instr),
 
                       .mem_wstrb(mem_wstrb),
-                      .mem_addr (mem_addr),
+                      .mem_addr(mem_addr),
                       .mem_wdata(mem_wdata),
                       .mem_rdata(mem_rdata),
-                      .unaligned_access_load  (unaligned_access_load),
-                      .unaligned_access_store (unaligned_access_store),
+                      .unaligned_access_load(unaligned_access_load),
+                      .unaligned_access_store(unaligned_access_store),
 
                       .MULop      (MULop),
                       .mul_valid  (mul_valid),
@@ -213,14 +213,14 @@ module kianv_harris_mc_edition #(
                       .ProgCounter(PC),
 
                       // AMO
-                      .amo_tmp_write              (amo_tmp_write),
-                      .amo_set_load_reserved_state(amo_set_load_reserved_state),
-                      .amo_intermediate_data      (amo_intermediate_data),
-                      .amo_intermediate_addr      (amo_intermediate_addr),
-                      .amo_load_reserved_state    (amo_load_reserved_state),
-                      .Aluout_or_amo_rd_wr_mux    (Aluout_or_amo_rd_wr_mux),
-                      .AMOWb_en                   (AMOWb_en),
-                      .amo_alu_op                 (amo_alu_op),
+                      .amo_temp_write_operation   (amo_temp_write_operation),
+                      .amo_set_reserved_state_load(amo_set_reserved_state_load),
+                      .amo_buffered_data          (amo_buffered_data),
+                      .amo_buffered_address       (amo_buffered_address),
+                      .amo_reserved_state_load    (amo_reserved_state_load),
+                      .muxed_Aluout_or_amo_rd_wr  (muxed_Aluout_or_amo_rd_wr),
+                      .select_ALUResult           (select_ALUResult),
+                      .select_amo_temp            (select_amo_temp),
 
                       // Exception
                       .exception_event (exception_event),
@@ -230,10 +230,10 @@ module kianv_harris_mc_edition #(
                       .wfi_event       (wfi_event),
                       .privilege_mode  (privilege_mode),
                       .csr_access_fault(csr_access_fault),
-                      .mie     (mie    ),
-                      .mip     (mip    ),
-                      .mstatus (mstatus),
-                      .IRQ3                       (IRQ3),
-                      .IRQ7                       (IRQ7)
+                      .mie             (mie),
+                      .mip             (mip),
+                      .mstatus         (mstatus),
+                      .IRQ3            (IRQ3),
+                      .IRQ7            (IRQ7)
                   );
 endmodule

--- a/Hardware/KianV-Apio/load_decoder.v
+++ b/Hardware/KianV-Apio/load_decoder.v
@@ -22,7 +22,7 @@
 module load_decoder
     (
         input  wire [ 2: 0] funct3,
-        input wire amo_load,
+        input wire amo_data_load,
         output reg  [`LOAD_OP_WIDTH -1: 0] LOADop
     );
     wire is_lb      = funct3 == 3'b 000;
@@ -32,7 +32,7 @@ module load_decoder
     wire is_lhu     = funct3 == 3'b 101;
 
     always @(*) begin
-        if (!amo_load) begin
+        if (!amo_data_load) begin
             case (1'b1)
                 is_lb  : LOADop = `LOAD_OP_LB;
                 is_lh  : LOADop = `LOAD_OP_LH;

--- a/Hardware/KianV-Apio/register_file.v
+++ b/Hardware/KianV-Apio/register_file.v
@@ -37,7 +37,7 @@ module register_file #(
     localparam X2 = 2;
     initial begin
         bank0[10] = 'h00;  // hartid
-        bank0[11] = 32'h80_000_000 + ((1024*1024*32)-2048);// 32'h81fffa00;  // dtb
+        bank0[11] = 32'h80_000_000 + ((1024 * 1024 * 32) - 2048);  // 32'h81fffa00;  // dtb
     end
 
 

--- a/Hardware/KianV-Apio/riscv_defines.vh
+++ b/Hardware/KianV-Apio/riscv_defines.vh
@@ -33,7 +33,8 @@
 `define SRCA_OLD_PC 1
 `define SRCA_RD1_BUF 2
 `define SRCA_AMO_TEMP_DATA 3
-`define SRCA_LAST 4
+`define SRCA_CONST_0 4
+`define SRCA_LAST 5
 
 // mux SRCB
 `define SRCB_WIDTH $clog2(`SRCB_LAST)

--- a/Hardware/KianV-Apio/store_alignment.v
+++ b/Hardware/KianV-Apio/store_alignment.v
@@ -31,7 +31,7 @@ module store_alignment (
 
     always @* begin
         unaligned_access = 1'b0;
-        wmask  = 0;
+        wmask = 0;
         result = 'hx;
 
         case (STOREop)
@@ -46,19 +46,19 @@ module store_alignment (
                 unaligned_access = 1'b0;
             end
             (`STORE_OP_SH): begin
-                result[15:0]  = ~addr[1] ? data[15:0] : 16'hx;
-                result[31:16] = addr[1] ? data[15:0] : 16'hx;
-                wmask         = addr[1] ? 4'b1100 : 4'b0011;
+                result[15:0]     = ~addr[1] ? data[15:0] : 16'hx;
+                result[31:16]    = addr[1] ? data[15:0] : 16'hx;
+                wmask            = addr[1] ? 4'b1100 : 4'b0011;
                 unaligned_access = addr[0];
             end
             (`STORE_OP_SW): begin
                 result = data;
-                wmask  = 4'b1111;
+                wmask = 4'b1111;
                 unaligned_access = addr[1:0] != 2'b00;
             end
             default: begin
                 result = 'hx;
-                wmask  = 4'b0000;
+                wmask = 4'b0000;
                 unaligned_access = 1'b0;
             end
         endcase

--- a/Hardware/KianV-Apio/store_decoder.v
+++ b/Hardware/KianV-Apio/store_decoder.v
@@ -22,7 +22,7 @@
 module store_decoder
     (
         input  wire [ 2: 0] funct3,
-        input wire amo_store_op,
+        input wire amo_operation_store,
         output reg  [`STORE_OP_WIDTH -1: 0] STOREop
     );
     wire is_sb      = funct3[1:0] == 2'b 00;
@@ -30,7 +30,7 @@ module store_decoder
     wire is_sw      = funct3[1:0] == 2'b 10;
 
     always @(*) begin
-        if (!amo_store_op) begin
+        if (!amo_operation_store) begin
             case (1'b1)
                 is_sb : STOREop = `STORE_OP_SB;
                 is_sh : STOREop = `STORE_OP_SH;
@@ -44,5 +44,4 @@ module store_decoder
             STOREop = `STORE_OP_SW;
         end
     end
-
 endmodule


### PR DESCRIPTION
commit fafa8f843e1788ec001a7a337eb87876e84f4ce9
Author: Hirosh Dabui <hirosh@dabui.de>
Date:   Fri Oct 6 20:11:20 2023 +0200

    Fix AMO kernel locking issue and rename signals

    - Resolved the atomic memory operation (AMO) locking problem in the kernel.
    - Renamed several signals for better clarity and consistency.